### PR TITLE
fix: Search by `nameKey` instead of `name`.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type Abilities = Ability[];
 
 export interface Pokemon {
   ID: number;
-  name: string;
+  name: string; // Base pokemon name. Same name for other forms of pokemon
   stats: number[]; // [HP, Attack, Defense, Speed, Sp. Atk, Sp. Def]
   type: number[]; // Type IDs
   abilities: Abilities; // [Ability ID, index]
@@ -19,7 +19,7 @@ export interface Pokemon {
   evolutions?: number[][];
   tmMoves?: number[]; // TM IDs
   tutorMoves?: number[]; // Tutor move IDs
-  nameKey: string; // Redundant name
+  nameKey: string; // Display name
   dexID: number; // National Dex ID
   ancestor: number; // Pre-evolution's ID
   eggMoves?: number[]; // Egg move IDs

--- a/src/utils/filterPokemon.ts
+++ b/src/utils/filterPokemon.ts
@@ -11,7 +11,7 @@ type FilterOptions = {
 
 function matchesNameFilter(pokemon: Pokemon, name?: string): boolean {
   return name
-    ? pokemon.name.toLowerCase().includes(name.toLowerCase())
+    ? pokemon.nameKey.toLowerCase().includes(name.toLowerCase())
     : true;
 }
 


### PR DESCRIPTION
`data.json` has the same `name` for pokemon even if their forms change, i.e. `Charizard-X-Mega`'s name is still `Charizard`. This commit changes what property gets compared to.

Fixes #6 